### PR TITLE
Stub out some edge cases to test.

### DIFF
--- a/tests/consensus.rs
+++ b/tests/consensus.rs
@@ -1,0 +1,37 @@
+//! Tests for consensus-critical validation rules.
+
+#[test]
+fn reject_non_canonical_field_encoding_of_signature_s() {
+    unimplemented!();
+}
+
+#[test]
+#[allow(non_snake_case)]
+fn accept_non_canonical_field_encoding_of_signature_R() {
+    unimplemented!();
+}
+
+#[test]
+#[allow(non_snake_case)]
+fn reject_low_order_signature_R() {
+    unimplemented!();
+}
+
+#[test]
+#[allow(non_snake_case)]
+fn accept_torsion_component_in_signature_R() {
+    unimplemented!();
+}
+
+#[test]
+#[allow(non_snake_case)]
+fn accept_non_canonical_field_encoding_of_pubkey_A() {
+    unimplemented!();
+}
+
+#[test]
+#[allow(non_snake_case)]
+fn reject_low_order_pubkey_A() {
+    unimplemented!();
+}
+


### PR DESCRIPTION
Replaces #2.  It's not immediately clear how to test these properties specifically (for instance, how to check that a signature with non-canonically encoded `R` is accepted, since there are only 19 points for which that's possible, so you need to construct a valid signature with one of those points).