### PR TITLE
Match libsodium behavior.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,31 @@ specifically, and since it is unreasonable to expect an upstream dependency to
 maintain Zcash-specific behavior, this crate provides an Ed25519 implementation
 matching the Zcash consensus rules exactly.
 
+## Example
+
+```
+use std::convert::TryFrom;
+use rand::thread_rng;
+use ed25519_zebra::*;
+
+let msg = b"Zcash";
+
+// Generate a secret key and sign the message
+let sk = SecretKey::new(thread_rng());
+let sig = sk.sign(msg);
+
+// Types can be converted to raw byte arrays with From/Into
+let sig_bytes: [u8; 64] = sig.into();
+let pk_bytes: [u8; 32] = PublicKey::from(&sk).into();
+
+// Verify the signature
+assert!(
+    PublicKey::try_from(pk_bytes)
+        .and_then(|pk| pk.verify(&sig_bytes.into(), msg))
+        .is_ok()
+);
+```
+
 [zcash_protocol_jssig]: https://zips.z.cash/protocol/protocol.pdf#concretejssig
 [RFC8032]: https://tools.ietf.org/html/rfc8032
 [zebra]: https://github.com/ZcashFoundation/zebra

--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -8,12 +8,26 @@ use sha2::{Digest, Sha512};
 
 use crate::{Error, Signature};
 
-/// A refinement type for `[u8; 32]` indicating that the bytes represent
-/// an encoding of an Ed25519 public key.
+/// A refinement type for `[u8; 32]` indicating that the bytes represent an
+/// encoding of an Ed25519 public key.
 ///
-/// This is useful for representing a compressed public key; the
-/// [`PublicKey`] type in this library holds other decompressed state
-/// used in signature verification.
+/// This is useful for representing an encoded public key, while the
+/// [`PublicKey`] type in this library caches other decoded state used in
+/// signature verification.  
+///
+/// A `PublicKeyBytes` can be used to verify a single signature using the
+/// following idiom:
+/// ```
+/// use std::convert::TryFrom;
+/// # use rand::thread_rng;
+/// # use ed25519_zebra::*;
+/// # let msg = b"Zcash";
+/// # let sk = SecretKey::new(thread_rng());
+/// # let sig = sk.sign(msg);
+/// # let pk_bytes: PublicKeyBytes = PublicKey::from(&sk).into();
+/// PublicKey::try_from(pk_bytes)
+///     .and_then(|pk| pk.verify(&sig, msg));
+/// ```
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PublicKeyBytes(pub(crate) [u8; 32]);


### PR DESCRIPTION
This closes #1 by bringing the implementation in line with the behavior implemented in `libsodium` `1.0.15`, and by documenting the consensus properties explicitly.