### PR TITLE
impl AsRef<[u8]> for PublicKeyBytes

### DIFF
--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -32,6 +32,12 @@ use crate::{Error, Signature};
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PublicKeyBytes(pub(crate) [u8; 32]);
 
+impl AsRef<[u8]> for PublicKeyBytes {
+    fn as_ref(&self) -> &[u8] {
+        &self.0[..]
+    }
+}
+
 impl From<[u8; 32]> for PublicKeyBytes {
     fn from(bytes: [u8; 32]) -> PublicKeyBytes {
         PublicKeyBytes(bytes)


### PR DESCRIPTION
It would be good to also implement AsRef<[u8]> for Signature but this requires
changing the internal representation of Signature.