### PR TITLE
Add impl AsRef<[u8]> for all types except Signature.

### DIFF
--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -91,6 +91,12 @@ impl From<PublicKey> for PublicKeyBytes {
     }
 }
 
+impl AsRef<[u8]> for PublicKey {
+    fn as_ref(&self) -> &[u8] {
+        &self.A_bytes.0[..]
+    }
+}
+
 impl From<PublicKey> for [u8; 32] {
     fn from(pk: PublicKey) -> [u8; 32] {
         pk.A_bytes.0

--- a/src/secret_key.rs
+++ b/src/secret_key.rs
@@ -28,6 +28,12 @@ impl<'a> From<&'a SecretKey> for PublicKeyBytes {
     }
 }
 
+impl AsRef<[u8]> for SecretKey {
+    fn as_ref(&self) -> &[u8] {
+        &self.seed[..]
+    }
+}
+
 impl From<SecretKey> for [u8; 32] {
     fn from(sk: SecretKey) -> [u8; 32] {
         sk.seed

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -1,6 +1,21 @@
 use rand::thread_rng;
 
-use ed25519_zebra::{PublicKey, SecretKey};
+use ed25519_zebra::{PublicKey, PublicKeyBytes, SecretKey};
+
+#[test]
+fn asref_vs_into_bytes() {
+    let sk = SecretKey::new(thread_rng());
+    let pk = PublicKey::from(&sk);
+    let pkb = PublicKeyBytes::from(&sk);
+
+    let sk_array: [u8; 32] = sk.into();
+    let pk_array: [u8; 32] = pk.into();
+    let pkb_array: [u8; 32] = pkb.into();
+
+    assert_eq!(&sk_array[..], sk.as_ref());
+    assert_eq!(&pk_array[..], pk.as_ref());
+    assert_eq!(&pkb_array[..], pkb.as_ref());
+}
 
 #[test]
 fn sign_and_verify() {


### PR DESCRIPTION
This ensures that any
```
impl From<T> for [u8; N]
```
is accompanied by a matching
```
impl AsRef<[u8]> for T
```
except for Signature, whose internals have to change (issue #9).