### PR TITLE
Use the hex crate for nicer debug output.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ description = "Zcash-flavored Ed25519 for use in Zebra."
 features = ["nightly", "batch"]
 
 [dependencies]
+hex = "0.4"
 sha2 = "0.8"
 rand_core = "0.5"
 thiserror = "1"
@@ -27,7 +28,6 @@ rand = { version = "0.7", optional = true }
 
 [dev-dependencies]
 rand = "0.7"
-hex = "0.4"
 bincode = "1"
 tokio = { version = "0.2", features = ["full"]}
 futures = "0.3"

--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -28,9 +28,17 @@ use crate::{Error, Signature};
 /// PublicKey::try_from(pk_bytes)
 ///     .and_then(|pk| pk.verify(&sig, msg));
 /// ```
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PublicKeyBytes(pub(crate) [u8; 32]);
+
+impl core::fmt::Debug for PublicKeyBytes {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+        fmt.debug_tuple("PublicKeyBytes")
+            .field(&hex::encode(&self.0))
+            .finish()
+    }
+}
 
 impl AsRef<[u8]> for PublicKeyBytes {
     fn as_ref(&self) -> &[u8] {

--- a/src/secret_key.rs
+++ b/src/secret_key.rs
@@ -5,7 +5,7 @@ use sha2::{Digest, Sha512};
 use crate::{PublicKey, PublicKeyBytes, Signature};
 
 /// An Ed25519 secret key.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(from = "SerdeHelper"))]
 #[cfg_attr(feature = "serde", serde(into = "SerdeHelper"))]
@@ -14,6 +14,17 @@ pub struct SecretKey {
     s: Scalar,
     prefix: [u8; 32],
     pk: PublicKey,
+}
+
+impl core::fmt::Debug for SecretKey {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+        fmt.debug_struct("SecretKey")
+            .field("seed", &hex::encode(&self.seed))
+            .field("s", &self.s)
+            .field("prefix", &hex::encode(&self.prefix))
+            .field("pk", &self.pk)
+            .finish()
+    }
 }
 
 impl<'a> From<&'a SecretKey> for PublicKey {

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -1,10 +1,19 @@
 /// An Ed25519 signature.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(non_snake_case)]
 pub struct Signature {
     pub(crate) R_bytes: [u8; 32],
     pub(crate) s_bytes: [u8; 32],
+}
+
+impl core::fmt::Debug for Signature {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+        fmt.debug_struct("Signature")
+            .field("R_bytes", &hex::encode(&self.R_bytes))
+            .field("s_bytes", &hex::encode(&self.s_bytes))
+            .finish()
+    }
 }
 
 impl From<[u8; 64]> for Signature {


### PR DESCRIPTION
This is mostly relevant for `PublicKeyBytes` and `Signature`, since they are byte wrappers, and makes their `Debug` output easier to read as bytes.