### PR TITLE
Change terminology to signing and verification keys.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,12 +9,12 @@
 mod batch;
 mod constants;
 mod error;
-mod public_key;
-mod secret_key;
 mod signature;
+mod signing_key;
+mod verification_key;
 
 pub use batch::BatchVerifier;
 pub use error::Error;
-pub use public_key::{PublicKey, PublicKeyBytes};
-pub use secret_key::SecretKey;
 pub use signature::Signature;
+pub use signing_key::SigningKey;
+pub use verification_key::{VerificationKey, VerificationKeyBytes};

--- a/tests/batch.rs
+++ b/tests/batch.rs
@@ -6,8 +6,8 @@ use ed25519_zebra::*;
 fn batch_verify() {
     let mut batch = BatchVerifier::new();
     for _ in 0..32 {
-        let sk = SecretKey::new(thread_rng());
-        let pk_bytes = PublicKeyBytes::from(&sk);
+        let sk = SigningKey::new(thread_rng());
+        let pk_bytes = VerificationKeyBytes::from(&sk);
         let msg = b"BatchVerifyTest";
         let sig = sk.sign(&msg[..]);
         batch.queue(pk_bytes, sig, &msg[..]);

--- a/tests/rfc8032.rs
+++ b/tests/rfc8032.rs
@@ -9,16 +9,16 @@ use ed25519_zebra::*;
 use hex;
 
 fn rfc8032_test_case(sk_bytes: Vec<u8>, pk_bytes: Vec<u8>, sig_bytes: Vec<u8>, msg: Vec<u8>) {
-    let sk: SecretKey = bincode::deserialize(&sk_bytes).expect("sk should deserialize");
-    let pk: PublicKey = bincode::deserialize(&pk_bytes).expect("pk should deserialize");
+    let sk: SigningKey = bincode::deserialize(&sk_bytes).expect("sk should deserialize");
+    let pk: VerificationKey = bincode::deserialize(&pk_bytes).expect("pk should deserialize");
     let sig: Signature = bincode::deserialize(&sig_bytes).expect("sig should deserialize");
 
     assert!(pk.verify(&sig, &msg).is_ok(), "verification failed");
 
-    let pk_from_sk = PublicKey::from(&sk);
+    let pk_from_sk = VerificationKey::from(&sk);
     assert_eq!(
-        PublicKeyBytes::from(pk),
-        PublicKeyBytes::from(pk_from_sk),
+        VerificationKeyBytes::from(pk),
+        VerificationKeyBytes::from(pk_from_sk),
         "regenerated pubkey did not match test vector pubkey"
     );
 

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -1,12 +1,12 @@
 use rand::thread_rng;
 
-use ed25519_zebra::{PublicKey, PublicKeyBytes, SecretKey};
+use ed25519_zebra::{SigningKey, VerificationKey, VerificationKeyBytes};
 
 #[test]
 fn asref_vs_into_bytes() {
-    let sk = SecretKey::new(thread_rng());
-    let pk = PublicKey::from(&sk);
-    let pkb = PublicKeyBytes::from(&sk);
+    let sk = SigningKey::new(thread_rng());
+    let pk = VerificationKey::from(&sk);
+    let pkb = VerificationKeyBytes::from(&sk);
 
     let sk_array: [u8; 32] = sk.into();
     let pk_array: [u8; 32] = pk.into();
@@ -19,8 +19,8 @@ fn asref_vs_into_bytes() {
 
 #[test]
 fn sign_and_verify() {
-    let sk = SecretKey::new(thread_rng());
-    let pk = PublicKey::from(&sk);
+    let sk = SigningKey::new(thread_rng());
+    let pk = VerificationKey::from(&sk);
 
     let msg = b"ed25519-zebra test message";
 


### PR DESCRIPTION
These are better names than secret and public keys, because they concisely
describe the functional *role* of the key material, not just whether or not the
key is revealed.