### PR TITLE
Fix batch verification API to be usable in async contexts.

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -44,9 +44,9 @@ fn bench_batch_verify(c: &mut Criterion) {
             &sigs,
             |b, sigs| {
                 b.iter(|| {
-                    let mut batch = BatchVerifier::new();
+                    let mut batch = batch::Verifier::new();
                     for (vk_bytes, sig) in sigs.iter().cloned() {
-                        batch.queue(vk_bytes, sig, b"");
+                        batch.queue((vk_bytes, sig, b""));
                     }
                     batch.verify(thread_rng())
                 })
@@ -58,9 +58,9 @@ fn bench_batch_verify(c: &mut Criterion) {
             &sigs,
             |b, sigs| {
                 b.iter(|| {
-                    let mut batch = BatchVerifier::new();
+                    let mut batch = batch::Verifier::new();
                     for (vk_bytes, sig) in sigs.iter().cloned() {
-                        batch.queue(vk_bytes, sig, b"");
+                        batch.queue((vk_bytes, sig, b""));
                     }
                     batch.verify(thread_rng())
                 })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,14 +6,13 @@
 
 //! Docs require the `nightly` feature until RFC 1990 lands.
 
-mod batch;
+pub mod batch;
 mod constants;
 mod error;
 mod signature;
 mod signing_key;
 mod verification_key;
 
-pub use batch::BatchVerifier;
 pub use error::Error;
 pub use signature::Signature;
 pub use signing_key::SigningKey;

--- a/tests/batch.rs
+++ b/tests/batch.rs
@@ -4,13 +4,13 @@ use ed25519_zebra::*;
 
 #[test]
 fn batch_verify() {
-    let mut batch = BatchVerifier::new();
+    let mut batch = batch::Verifier::new();
     for _ in 0..32 {
         let sk = SigningKey::new(thread_rng());
         let pk_bytes = VerificationKeyBytes::from(&sk);
         let msg = b"BatchVerifyTest";
         let sig = sk.sign(&msg[..]);
-        batch.queue(pk_bytes, sig, &msg[..]);
+        batch.queue((pk_bytes, sig, msg));
     }
     assert!(batch.verify(thread_rng()).is_ok());
 }


### PR DESCRIPTION
It's essential to be able to separate the lifetime of the batch item from the
lifetime of associated data (in this case, the message).  The previous API did
this mixed in to the Tower implementation, but it was removed along with that
code.

Making the `queue` function take `I: Into<Item>` means that users who don't
care about lifetimes just need to wrap the function arguments in an extra
tuple.