### PR TITLE
Add impl TryFrom<&[u8]> for all types.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -12,4 +12,7 @@ pub enum Error {
     /// Signature verification failed.
     #[error("Invalid signature.")]
     InvalidSignature,
+    /// A byte slice of the wrong length was supplied during parsing.
+    #[error("Invalid length when parsing byte slice.")]
+    InvalidSliceLength,
 }

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -1,3 +1,6 @@
+use crate::Error;
+use std::convert::TryFrom;
+
 /// An Ed25519 signature.
 #[derive(Copy, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -24,6 +27,20 @@ impl From<[u8; 64]> for Signature {
         let mut s_bytes = [0; 32];
         s_bytes.copy_from_slice(&bytes[32..64]);
         Signature { R_bytes, s_bytes }
+    }
+}
+
+impl TryFrom<&[u8]> for Signature {
+    type Error = Error;
+
+    fn try_from(slice: &[u8]) -> Result<Signature, Error> {
+        if slice.len() == 64 {
+            let mut bytes = [0u8; 64];
+            bytes[..].copy_from_slice(slice);
+            Ok(bytes.into())
+        } else {
+            Err(Error::InvalidSliceLength)
+        }
     }
 }
 

--- a/src/signing_key.rs
+++ b/src/signing_key.rs
@@ -1,8 +1,10 @@
+use std::convert::TryFrom;
+
 use curve25519_dalek::{constants, scalar::Scalar};
 use rand_core::{CryptoRng, RngCore};
 use sha2::{Digest, Sha512};
 
-use crate::{Signature, VerificationKey, VerificationKeyBytes};
+use crate::{Error, Signature, VerificationKey, VerificationKeyBytes};
 
 /// An Ed25519 signing key.
 ///
@@ -50,6 +52,19 @@ impl AsRef<[u8]> for SigningKey {
 impl From<SigningKey> for [u8; 32] {
     fn from(sk: SigningKey) -> [u8; 32] {
         sk.seed
+    }
+}
+
+impl TryFrom<&[u8]> for SigningKey {
+    type Error = Error;
+    fn try_from(slice: &[u8]) -> Result<SigningKey, Error> {
+        if slice.len() == 32 {
+            let mut bytes = [0u8; 32];
+            bytes[..].copy_from_slice(slice);
+            Ok(bytes.into())
+        } else {
+            Err(Error::InvalidSliceLength)
+        }
     }
 }
 

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -1,20 +1,43 @@
+use std::convert::TryFrom;
+
 use rand::thread_rng;
 
-use ed25519_zebra::{SigningKey, VerificationKey, VerificationKeyBytes};
+use ed25519_zebra::{Signature, SigningKey, VerificationKey, VerificationKeyBytes};
 
 #[test]
-fn asref_vs_into_bytes() {
+fn parsing() {
     let sk = SigningKey::new(thread_rng());
     let pk = VerificationKey::from(&sk);
     let pkb = VerificationKeyBytes::from(&sk);
+    let sig = sk.sign(b"test");
+
+    // Most of these types don't implement Eq, so we check a round trip
+    // conversion to bytes, using these as the reference points:
 
     let sk_array: [u8; 32] = sk.into();
     let pk_array: [u8; 32] = pk.into();
     let pkb_array: [u8; 32] = pkb.into();
+    let sig_array: [u8; 64] = sig.into();
 
-    assert_eq!(&sk_array[..], sk.as_ref());
-    assert_eq!(&pk_array[..], pk.as_ref());
-    assert_eq!(&pkb_array[..], pkb.as_ref());
+    let sk2 = SigningKey::try_from(sk.as_ref()).unwrap();
+    let pk2 = VerificationKey::try_from(pk.as_ref()).unwrap();
+    let pkb2 = VerificationKeyBytes::try_from(pkb.as_ref()).unwrap();
+    let sig2 = Signature::try_from(<[u8; 64]>::from(sig).as_ref()).unwrap();
+
+    assert_eq!(&sk_array[..], sk2.as_ref());
+    assert_eq!(&pk_array[..], pk2.as_ref());
+    assert_eq!(&pkb_array[..], pkb2.as_ref());
+    assert_eq!(&sig_array[..], <[u8; 64]>::from(sig2).as_ref());
+
+    let sk3: SigningKey = bincode::deserialize(sk.as_ref()).unwrap();
+    let pk3: VerificationKey = bincode::deserialize(pk.as_ref()).unwrap();
+    let pkb3: VerificationKeyBytes = bincode::deserialize(pkb.as_ref()).unwrap();
+    let sig3: Signature = bincode::deserialize(<[u8; 64]>::from(sig).as_ref()).unwrap();
+
+    assert_eq!(&sk_array[..], sk3.as_ref());
+    assert_eq!(&pk_array[..], pk3.as_ref());
+    assert_eq!(&pkb_array[..], pkb3.as_ref());
+    assert_eq!(&sig_array[..], <[u8; 64]>::from(sig3).as_ref());
 }
 
 #[test]


### PR DESCRIPTION
This makes the API slightly more ergonomic.  Merging this in advance of #24 so that 1.x and 2.x series have the same API.