### PR TITLE
Add missing mul_by_cofactor in batch verification.

### DIFF
--- a/src/batch.rs
+++ b/src/batch.rs
@@ -209,7 +209,7 @@ impl Verifier {
             once(&B).chain(As.iter()).chain(Rs.iter()),
         );
 
-        if check.is_identity() {
+        if check.mul_by_cofactor().is_identity() {
             Ok(())
         } else {
             Err(Error::InvalidSignature)


### PR DESCRIPTION
This should have been added as part of the ZIP 215 work but I missed it.  Fixed and tested.