### PR TITLE
Add missing mul_by_cofactor in batch verification.

### DIFF
--- a/src/batch.rs
+++ b/src/batch.rs
@@ -188,7 +188,7 @@ impl Verifier {
             once(&B).chain(As.iter()).chain(Rs.iter()),
         );
 
-        if check.is_identity() {
+        if check.mul_by_cofactor().is_identity() {
             Ok(())
         } else {
             Err(Error::InvalidSignature)


### PR DESCRIPTION
Backport of #28 to 1.x series.