### PR TITLE
Update sha2 to 0.9 and curve25519-dalek to 3.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ features = ["nightly"]
 
 [dependencies]
 hex = "0.4"
-sha2 = "0.8"
+sha2 = "0.9"
 rand_core = "0.5"
 thiserror = "1"
-curve25519-dalek = "2"
+curve25519-dalek = "3"
 serde = { version = "1", optional = true, features = ["derive"] }
 
 [dev-dependencies]


### PR DESCRIPTION
This is done as a commit on the 1.x series, which can be cherry-picked to the 2.x series.  Interestingly, because the code uses `.chain`, no changes to the code are required.