### PR TITLE
Add *Ord instances to VerificationKeyBytes

### DIFF
--- a/src/verification_key.rs
+++ b/src/verification_key.rs
@@ -29,7 +29,7 @@ use crate::{Error, Signature};
 /// VerificationKey::try_from(vk_bytes)
 ///     .and_then(|vk| vk.verify(&sig, msg));
 /// ```
-#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VerificationKeyBytes(pub(crate) [u8; 32]);
 


### PR DESCRIPTION
This makes it possible to key a `BTreeMap` for example, with a public key.