### PR TITLE
Update to curve25519-dalek-ng (1.x)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ hex = "0.4"
 sha2 = "0.9"
 rand_core = "0.5"
 thiserror = "1"
-curve25519-dalek = "3"
+curve25519-dalek = { package = "curve25519-dalek-ng", version = "3" }
 serde = { version = "1", optional = true, features = ["derive"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Updates the `curve25519-dalek` dependency in the `1.x` series to the `-ng` version at `zkcrypto` https://github.com/zkcrypto/curve25519-dalek-ng