### PR TITLE
Use curve25519-dalek-ng as dependency instead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ hex = "0.4"
 sha2 = "0.9"
 rand_core = "0.6"
 thiserror = "1"
-curve25519-dalek = "3"
+curve25519-dalek-ng = "4"
 serde = { version = "1", optional = true, features = ["derive"] }
 zeroize = "1.1"
 

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -50,7 +50,7 @@
 
 use std::{collections::HashMap, convert::TryFrom};
 
-use curve25519_dalek::{
+use curve25519_dalek_ng::{
     edwards::{CompressedEdwardsY, EdwardsPoint},
     scalar::Scalar,
     traits::{IsIdentity, VartimeMultiscalarMul},
@@ -202,7 +202,7 @@ impl Verifier {
             A_coeffs.push(A_coeff);
         }
 
-        use curve25519_dalek::constants::ED25519_BASEPOINT_POINT as B;
+        use curve25519_dalek_ng::constants::ED25519_BASEPOINT_POINT as B;
         use std::iter::once;
         let check = EdwardsPoint::vartime_multiscalar_mul(
             once(&B_coeff).chain(A_coeffs.iter()).chain(R_coeffs.iter()),

--- a/src/signing_key.rs
+++ b/src/signing_key.rs
@@ -1,6 +1,6 @@
 use std::convert::TryFrom;
 
-use curve25519_dalek::{constants, scalar::Scalar};
+use curve25519_dalek_ng::{constants, scalar::Scalar};
 use rand_core::{CryptoRng, RngCore};
 use sha2::{Digest, Sha512};
 

--- a/src/verification_key.rs
+++ b/src/verification_key.rs
@@ -1,6 +1,6 @@
 use std::convert::{TryFrom, TryInto};
 
-use curve25519_dalek::{
+use curve25519_dalek_ng::{
     edwards::{CompressedEdwardsY, EdwardsPoint},
     scalar::Scalar,
     traits::IsIdentity,

--- a/tests/small_order.rs
+++ b/tests/small_order.rs
@@ -1,5 +1,5 @@
 use color_eyre::Report;
-use curve25519_dalek::{
+use curve25519_dalek_ng::{
     constants::EIGHT_TORSION, edwards::CompressedEdwardsY, scalar::Scalar, traits::IsIdentity,
 };
 use once_cell::sync::Lazy;

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -2,7 +2,7 @@
 #![allow(dead_code)]
 
 use color_eyre::{eyre::eyre, Report};
-use curve25519_dalek::edwards::{CompressedEdwardsY, EdwardsPoint};
+use curve25519_dalek_ng::edwards::{CompressedEdwardsY, EdwardsPoint};
 use ed25519_zebra as ed25519_zebra_zip215;
 
 use std::convert::TryFrom;
@@ -168,7 +168,7 @@ fn print_non_canonical_points() {
 }
 
 pub fn order(point: EdwardsPoint) -> &'static str {
-    use curve25519_dalek::traits::IsIdentity;
+    use curve25519_dalek_ng::traits::IsIdentity;
     if point.is_small_order() {
         let point2 = point + point;
         let point4 = point2 + point2;


### PR DESCRIPTION
The former curve25519-dalek repository is inactive/not longer
maintained and the repository was forked and is maintained by the
zcrypto organization:
https://github.com/zkcrypto/curve25519-dalek-ng.
Now the crate is called curve25519-dalek-ng and its latest version
is 4.