### PR TITLE
dependencies: update zeroize to 1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rand_core = "0.6"
 thiserror = "1"
 curve25519-dalek = "3"
 serde = { version = "1", optional = true, features = ["derive"] }
-zeroize = "1.1"
+zeroize = "1.2"
 
 [dev-dependencies]
 rand = "0.8"


### PR DESCRIPTION
There was a vulnerability reported[0] in zeroize which is patches with
versions >=1.2.0. This patch sets the bound to "1.2" in the Cargo.toml.

[0]: https://rustsec.org/advisories/RUSTSEC-2021-0115

Signed-off-by: Fintan Halpenny <fintan.halpenny@gmail.com>