### PR TITLE
Add `no_std` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,18 +8,19 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 repository = "https://github.com/ZcashFoundation/ed25519-zebra"
 description = "Zcash-flavored Ed25519 for use in Zebra."
+resolver = "2"
 
 [package.metadata.docs.rs]
 features = ["nightly"]
 
 [dependencies]
-hex = "0.4"
-sha2 = "0.9"
+hex = { version = "0.4", default-features = false, features = ["alloc"] }
+sha2 = { version = "0.9", default-features = false }
 rand_core = "0.6"
-thiserror = "1"
-curve25519-dalek = "3"
+curve25519-dalek = { version = "3", default-features = false, features = ["alloc", "u64_backend"] }
 serde = { version = "1", optional = true, features = ["derive"] }
 zeroize = "1.2"
+hashbrown = "0.12.0"
 
 [dev-dependencies]
 rand = "0.8"
@@ -31,7 +32,8 @@ once_cell = "1.4"
 
 [features]
 nightly = []
-default = ["serde"]
+default = ["serde", "std"]
+std = []
 
 [[test]]
 name = "rfc8032"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,8 +1,8 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 
+use core::convert::TryFrom;
 use ed25519_zebra::*;
 use rand::thread_rng;
-use std::convert::TryFrom;
 
 fn sigs_with_distinct_pubkeys() -> impl Iterator<Item = (VerificationKeyBytes, Signature)> {
     std::iter::repeat_with(|| {

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -48,13 +48,15 @@
 //!
 //! [ZIP215]: https://github.com/zcash/zips/blob/master/zip-0215.rst
 
-use std::{collections::HashMap, convert::TryFrom};
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 
 use curve25519_dalek::{
     edwards::{CompressedEdwardsY, EdwardsPoint},
     scalar::Scalar,
     traits::{IsIdentity, VartimeMultiscalarMul},
 };
+use hashbrown::HashMap;
 use rand_core::{CryptoRng, RngCore};
 use sha2::{Digest, Sha512};
 
@@ -202,8 +204,8 @@ impl Verifier {
             A_coeffs.push(A_coeff);
         }
 
+        use core::iter::once;
         use curve25519_dalek::constants::ED25519_BASEPOINT_POINT as B;
-        use std::iter::once;
         let check = EdwardsPoint::vartime_multiscalar_mul(
             once(&B_coeff).chain(A_coeffs.iter()).chain(R_coeffs.iter()),
             once(&B).chain(As.iter()).chain(Rs.iter()),

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,18 +1,30 @@
-use thiserror::Error;
+use core::fmt;
 
 /// An error related to Ed25519 signatures.
-#[derive(Error, Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum Error {
     /// The encoding of a secret key was malformed.
-    #[error("Malformed secret key encoding.")]
     MalformedSecretKey,
     /// The encoding of a public key was malformed.
-    #[error("Malformed public key encoding.")]
     MalformedPublicKey,
     /// Signature verification failed.
-    #[error("Invalid signature.")]
     InvalidSignature,
     /// A byte slice of the wrong length was supplied during parsing.
-    #[error("Invalid length when parsing byte slice.")]
     InvalidSliceLength,
 }
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg = match self {
+            Self::MalformedSecretKey => "Malformed secret key encoding.",
+            Self::MalformedPublicKey => "Malformed public key encoding.",
+            Self::InvalidSignature => "Invalid signature.",
+            Self::InvalidSliceLength => "Invalid length when parsing byte slice.",
+        };
+
+        msg.fmt(f)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,12 @@
 #![deny(missing_docs)]
 #![doc = include_str!("../README.md")]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 //! Docs require the `nightly` feature until RFC 1990 lands.
+
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
 
 pub mod batch;
 mod error;

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -1,5 +1,5 @@
 use crate::Error;
-use std::convert::TryFrom;
+use core::convert::TryFrom;
 
 /// An Ed25519 signature.
 #[derive(Copy, Clone, Eq, PartialEq)]

--- a/src/signing_key.rs
+++ b/src/signing_key.rs
@@ -1,4 +1,4 @@
-use std::convert::TryFrom;
+use core::convert::TryFrom;
 
 use curve25519_dalek::{constants, scalar::Scalar};
 use rand_core::{CryptoRng, RngCore};

--- a/src/verification_key.rs
+++ b/src/verification_key.rs
@@ -1,4 +1,4 @@
-use std::convert::{TryFrom, TryInto};
+use core::convert::{TryFrom, TryInto};
 
 use curve25519_dalek::{
     edwards::{CompressedEdwardsY, EdwardsPoint},
@@ -19,7 +19,7 @@ use crate::{Error, Signature};
 /// A `VerificationKeyBytes` can be used to verify a single signature using the
 /// following idiom:
 /// ```
-/// use std::convert::TryFrom;
+/// use core::convert::TryFrom;
 /// # use rand::thread_rng;
 /// # use ed25519_zebra::*;
 /// # let msg = b"Zcash";

--- a/tests/small_order.rs
+++ b/tests/small_order.rs
@@ -87,8 +87,8 @@ fn conformance() -> Result<(), Report> {
 
 #[test]
 fn individual_matches_batch_verification() -> Result<(), Report> {
+    use core::convert::TryFrom;
     use ed25519_zebra::{batch, Signature, VerificationKey, VerificationKeyBytes};
-    use std::convert::TryFrom;
     for case in SMALL_ORDER_SIGS.iter() {
         let msg = b"Zcash";
         let sig = Signature::from(case.sig_bytes);

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -1,4 +1,4 @@
-use std::convert::TryFrom;
+use core::convert::TryFrom;
 
 use rand::thread_rng;
 

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -5,7 +5,7 @@ use color_eyre::{eyre::eyre, Report};
 use curve25519_dalek::edwards::{CompressedEdwardsY, EdwardsPoint};
 use ed25519_zebra as ed25519_zebra_zip215;
 
-use std::convert::TryFrom;
+use core::convert::TryFrom;
 pub struct TestCase {
     pub vk_bytes: [u8; 32],
     pub sig_bytes: [u8; 64],


### PR DESCRIPTION
This PR adds `no_std` support to `ed25519-zebra` and keeps all the `std` related bits under a feature with the same name.