### PR TITLE
update curve25519-dalek to 4.0.0-pre.5; sha2 to 0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Entries are listed in reverse chronological order.
 
+# 3.2.0
+
+* Updates `sha2` version to `0.10` and `curve25519-dalek` version to `4.0.0-pre.5`.
+
+MSRV increased to `1.60.0`.
+
 # 3.1.0
 
 * Add no_std support by @pvdrz in https://github.com/ZcashFoundation/ed25519-zebra/pull/57

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,12 @@ features = ["nightly"]
 
 [dependencies]
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
-sha2 = { version = "0.9", default-features = false }
+sha2 = { version = "0.10", default-features = false }
 rand_core = "0.6"
-curve25519-dalek = { version = "3", default-features = false, features = ["alloc", "u64_backend"] }
+# "digest" is exempt from SemVer, so we should always use a specific version
+curve25519-dalek = { version = "=4.0.0-pre.5", default-features = false, features = ["alloc", "digest"] }
 serde = { version = "1", optional = true, features = ["derive"] }
-zeroize = "1.2"
+zeroize = "1.5"
 hashbrown = "0.12.0"
 
 [dev-dependencies]

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -52,13 +52,14 @@ use alloc::vec::Vec;
 use core::convert::TryFrom;
 
 use curve25519_dalek::{
+    digest::Update,
     edwards::{CompressedEdwardsY, EdwardsPoint},
     scalar::Scalar,
     traits::{IsIdentity, VartimeMultiscalarMul},
 };
 use hashbrown::HashMap;
 use rand_core::{CryptoRng, RngCore};
-use sha2::{Digest, Sha512};
+use sha2::Sha512;
 
 use crate::{Error, Signature, VerificationKey, VerificationKeyBytes};
 
@@ -179,20 +180,21 @@ impl Verifier {
         let mut As = Vec::with_capacity(m);
         let mut R_coeffs = Vec::with_capacity(self.batch_size);
         let mut Rs = Vec::with_capacity(self.batch_size);
-        let mut B_coeff = Scalar::zero();
+        let mut B_coeff = Scalar::ZERO;
 
         for (vk_bytes, sigs) in self.signatures.iter() {
             let A = CompressedEdwardsY(vk_bytes.0)
                 .decompress()
                 .ok_or(Error::InvalidSignature)?;
 
-            let mut A_coeff = Scalar::zero();
+            let mut A_coeff = Scalar::ZERO;
 
             for (k, sig) in sigs.iter() {
                 let R = CompressedEdwardsY(sig.R_bytes)
                     .decompress()
                     .ok_or(Error::InvalidSignature)?;
-                let s = Scalar::from_canonical_bytes(sig.s_bytes).ok_or(Error::InvalidSignature)?;
+                let s = Option::<Scalar>::from(Scalar::from_canonical_bytes(sig.s_bytes))
+                    .ok_or(Error::InvalidSignature)?;
                 let z = Scalar::from(gen_u128(&mut rng));
                 B_coeff -= z * s;
                 Rs.push(R);

--- a/src/signing_key.rs
+++ b/src/signing_key.rs
@@ -1,6 +1,6 @@
 use core::convert::TryFrom;
 
-use curve25519_dalek::{constants, scalar::Scalar};
+use curve25519_dalek::{constants, digest::Update, scalar::Scalar};
 use rand_core::{CryptoRng, RngCore};
 use sha2::{Digest, Sha512};
 

--- a/src/verification_key.rs
+++ b/src/verification_key.rs
@@ -1,11 +1,12 @@
 use core::convert::{TryFrom, TryInto};
 
 use curve25519_dalek::{
+    digest::Update,
     edwards::{CompressedEdwardsY, EdwardsPoint},
     scalar::Scalar,
     traits::IsIdentity,
 };
-use sha2::{Digest, Sha512};
+use sha2::Sha512;
 
 use crate::{Error, Signature};
 
@@ -14,7 +15,7 @@ use crate::{Error, Signature};
 ///
 /// This is useful for representing an encoded verification key, while the
 /// [`VerificationKey`] type in this library caches other decoded state used in
-/// signature verification.  
+/// signature verification.
 ///
 /// A `VerificationKeyBytes` can be used to verify a single signature using the
 /// following idiom:
@@ -185,7 +186,8 @@ impl VerificationKey {
     #[allow(non_snake_case)]
     pub(crate) fn verify_prehashed(&self, signature: &Signature, k: Scalar) -> Result<(), Error> {
         // `s_bytes` MUST represent an integer less than the prime `l`.
-        let s = Scalar::from_canonical_bytes(signature.s_bytes).ok_or(Error::InvalidSignature)?;
+        let s = Option::<Scalar>::from(Scalar::from_canonical_bytes(signature.s_bytes))
+            .ok_or(Error::InvalidSignature)?;
         // `R_bytes` MUST be an encoding of a point on the twisted Edwards form of Curve25519.
         let R = CompressedEdwardsY(signature.R_bytes)
             .decompress()

--- a/tests/small_order.rs
+++ b/tests/small_order.rs
@@ -1,9 +1,10 @@
 use color_eyre::Report;
 use curve25519_dalek::{
-    constants::EIGHT_TORSION, edwards::CompressedEdwardsY, scalar::Scalar, traits::IsIdentity,
+    constants::EIGHT_TORSION, digest::Update, edwards::CompressedEdwardsY, scalar::Scalar,
+    traits::IsIdentity,
 };
 use once_cell::sync::Lazy;
-use sha2::{Digest, Sha512};
+use sha2::Sha512;
 
 mod util;
 use util::TestCase;
@@ -11,7 +12,7 @@ use util::TestCase;
 #[allow(non_snake_case)]
 pub static SMALL_ORDER_SIGS: Lazy<Vec<TestCase>> = Lazy::new(|| {
     let mut tests = Vec::new();
-    let s = Scalar::zero();
+    let s = Scalar::ZERO;
 
     // Use all the canonical encodings of the 8-torsion points,
     // and the low-order non-canonical encodings.


### PR DESCRIPTION
Closes https://github.com/ZcashFoundation/ed25519-zebra/issues/66

Note sure if we should use 4.0.0, 3.2.0 or 3.1.1. I went with the second.