### PR TITLE
Do not log SigningKey seed, prefix, s, as part of impl Debug

### DIFF
--- a/src/signing_key.rs
+++ b/src/signing_key.rs
@@ -23,9 +23,6 @@ pub struct SigningKey {
 impl core::fmt::Debug for SigningKey {
     fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
         fmt.debug_struct("SigningKey")
-            .field("seed", &hex::encode(&self.seed))
-            .field("s", &self.s)
-            .field("prefix", &hex::encode(&self.prefix))
             .field("vk", &self.vk)
             .finish()
     }


### PR DESCRIPTION
We should not log secret data in general.

Resolves https://github.com/ZcashFoundation/ed25519-zebra/issues/71