### PR TITLE
fix order() function used in tests that showed an incorrect order

### DIFF
--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -184,7 +184,7 @@ pub fn order(point: EdwardsPoint) -> &'static str {
     } else if point.is_torsion_free() {
         "p"
     } else {
-        "8p"
+        ">p"
     }
 }
 


### PR DESCRIPTION
It is only used to show information about the order of non-canonical points (it doesn't influence the tests themselves), so I just fixed how it's shown to the user per @daira 's suggestion.

Closes https://github.com/ZcashFoundation/ed25519-zebra/issues/83