### PR TITLE
Add `alloc` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,17 +18,17 @@ features = ["nightly"]
 # (see https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek#stable)
 # (see https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek#public-api-semver-exemptions)
 # so only allow patch changes inside known compatible range
-curve25519-dalek = { version = ">= 4.0, < 4.2", default-features = false, features = ["alloc", "digest", "zeroize", "precomputed-tables"] }
+curve25519-dalek = { version = ">= 4.0, < 4.2", default-features = false, features = ["digest", "zeroize", "precomputed-tables"] }
 der = { version = "0.7.9", optional = true }
 ed25519 = { version = "2.2.3", default-features = false }
 hashbrown = "0.14.5"
-hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
-pkcs8 = { version = "0.10.1", optional = true, features = ["alloc", "pem"] }
+hex = { version = "0.4.3", default-features = false }
+pkcs8 = { version = "0.10.1", optional = true, features = ["pem"] }
 rand_core = "0.6"
 serde = { version = "1", default-features = false, optional = true, features = ["derive"] }
 sha2 = { version = "0.10", default-features = false }
 subtle = { version = "2.6.1", default-features = false }
-zeroize = { version = "1.8", features = [ "zeroize_derive" ] }
+zeroize = { version = "1.8", default-features = false, features = [ "derive" ] }
 
 [dev-dependencies]
 rand = "0.8"
@@ -41,10 +41,17 @@ once_cell = "1.19"
 [features]
 nightly = []
 default = ["serde", "std"]
+alloc = [
+    "curve25519-dalek/alloc",
+    "ed25519/alloc",
+    "hex/alloc",
+    "pkcs8/alloc",
+    "zeroize/alloc",
+]
 pem = ["der", "ed25519/pem"]
 pkcs8 = ["dep:pkcs8"]
 serde = ["dep:serde", "ed25519/serde"]
-std = ["ed25519/std", "subtle/std"]
+std = ["alloc", "ed25519/std", "subtle/std"]
 
 [[test]]
 name = "rfc8032"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ alloc = [
     "curve25519-dalek/alloc",
     "ed25519/alloc",
     "hex/alloc",
-    "pkcs8/alloc",
+    "pkcs8?/alloc",
     "zeroize/alloc",
 ]
 pem = ["der", "ed25519/pem"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ curve25519-dalek = { version = ">= 4.0, < 4.2", default-features = false, featur
 der = { version = "0.7.9", optional = true }
 ed25519 = { version = "2.2.3", default-features = false }
 hashbrown = "0.14.5"
-hex = { version = "0.4.3", default-features = false }
 pkcs8 = { version = "0.10.1", optional = true, features = ["pem"] }
 rand_core = "0.6"
 serde = { version = "1", default-features = false, optional = true, features = ["derive"] }
@@ -36,6 +35,7 @@ bincode = "1"
 criterion = "0.5"
 ed25519-zebra-legacy = { package = "ed25519-zebra", version = "1" }
 color-eyre = "0.6"
+hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 once_cell = "1.19"
 
 [features]
@@ -44,7 +44,6 @@ default = ["serde", "std"]
 alloc = [
     "curve25519-dalek/alloc",
     "ed25519/alloc",
-    "hex/alloc",
     "pkcs8?/alloc",
     "zeroize/alloc",
 ]

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -39,6 +39,7 @@ fn bench_batch_verify(c: &mut Criterion) {
                 })
             },
         );
+        #[cfg(feature = "alloc")]
         group.bench_with_input(
             BenchmarkId::new("Signatures with Distinct Pubkeys", n),
             &sigs,
@@ -52,7 +53,9 @@ fn bench_batch_verify(c: &mut Criterion) {
                 })
             },
         );
+        #[cfg(feature = "alloc")]
         let sigs = sigs_with_same_pubkey().take(*n).collect::<Vec<_>>();
+        #[cfg(feature = "alloc")]
         group.bench_with_input(
             BenchmarkId::new("Signatures with the Same Pubkey", n),
             &sigs,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,10 +4,10 @@
 
 //! Docs require the `nightly` feature until RFC 1990 lands.
 
+#[cfg(feature = "alloc")]
 extern crate alloc;
-#[cfg(feature = "std")]
-extern crate std;
 
+#[cfg(feature = "alloc")]
 pub mod batch;
 mod error;
 mod signing_key;

--- a/src/verification_key.rs
+++ b/src/verification_key.rs
@@ -51,7 +51,7 @@ pub struct VerificationKeyBytes(pub(crate) [u8; 32]);
 impl core::fmt::Debug for VerificationKeyBytes {
     fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
         fmt.debug_tuple("VerificationKeyBytes")
-            .field(&hex::encode(self.0))
+            .field(&self.0)
             .finish()
     }
 }

--- a/tests/batch.rs
+++ b/tests/batch.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "alloc")]
+
 use rand::thread_rng;
 
 use ed25519_zebra::*;

--- a/tests/small_order.rs
+++ b/tests/small_order.rs
@@ -81,6 +81,7 @@ fn conformance() -> Result<(), Report> {
     Ok(())
 }
 
+#[cfg(feature = "alloc")]
 #[test]
 fn individual_matches_batch_verification() -> Result<(), Report> {
     use core::convert::TryFrom;


### PR DESCRIPTION
Resolves https://github.com/ZcashFoundation/ed25519-zebra/issues/160

Ideally MSRV would be bumped to 1.81.0+ so `core::error::Error` becomes available and tests can actually compile with `--no-default-features` (right now they don't and I was lazy making them compile).