### PR TITLE
add include directive to not package unnecessary files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,13 @@ edition = "2018"
 repository = "https://github.com/ZcashFoundation/ed25519-zebra"
 description = "Zcash-flavored Ed25519 for use in Zebra."
 resolver = "2"
+include = [
+    "/src",
+    "/*.md",
+    "/LICENSE-*",
+    "/tests",
+    "/benches",
+]
 
 [package.metadata.docs.rs]
 features = ["nightly"]


### PR DESCRIPTION
Closes https://github.com/ZcashFoundation/ed25519-zebra/issues/158

I kept tests and benchmarks because that seems to be done by major packages, and it also helps `cargo package` validate the package contents.