### PR TITLE
Only enable `hashbrown` dependency for `alloc` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,13 @@ features = ["nightly"]
 curve25519-dalek = { version = ">= 4.0, < 4.2", default-features = false, features = ["digest", "zeroize", "precomputed-tables"] }
 der = { version = "0.7.9", optional = true }
 ed25519 = { version = "2.2.3", default-features = false }
-hashbrown = "0.14.5"
+hashbrown = { version = "0.14.5", optional = true }
 pkcs8 = { version = "0.10.1", optional = true, features = ["pem"] }
 rand_core = "0.6"
 serde = { version = "1", default-features = false, optional = true, features = ["derive"] }
 sha2 = { version = "0.10", default-features = false }
 subtle = { version = "2.6.1", default-features = false }
-zeroize = { version = "1.8", default-features = false, features = [ "derive" ] }
+zeroize = { version = "1.8", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 rand = "0.8"
@@ -44,6 +44,7 @@ default = ["serde", "std"]
 alloc = [
     "curve25519-dalek/alloc",
     "ed25519/alloc",
+    "hashbrown",
     "pkcs8?/alloc",
     "zeroize/alloc",
 ]


### PR DESCRIPTION
https://github.com/ZcashFoundation/ed25519-zebra/pull/161 was a bit incomplete because `hashbrown` was pulling `once_cell` that doesn't work without `alloc`.

Would be nice to have a CI job that tests this, but I was too lazy to add it. I did confirm it doesn't require `alloc` though :slightly_smiling_face: 

cc @conradoplg